### PR TITLE
New bxml verbs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -123,8 +123,10 @@
  * [Gather](bxml/verbs/gather.md)
  * [Hangup](bxml/verbs/hangup.md)
  * [PlayAudio](bxml/verbs/playAudio.md)
+ * [Pause](bxml/verbs/pause.md)
  * [Record](bxml/verbs/record.md)
  * [Redirect](bxml/verbs/redirect.md)
+ * [SendDTMF](bxml/verbs/sendDtmf.md)
  * [SpeakSentence](bxml/verbs/speakSentence.md)
  * [Transfer](bxml/verbs/transfer.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -126,7 +126,7 @@
  * [Pause](bxml/verbs/pause.md)
  * [Record](bxml/verbs/record.md)
  * [Redirect](bxml/verbs/redirect.md)
- * [SendDTMF](bxml/verbs/sendDtmf.md)
+ * [SendDtmf](bxml/verbs/sendDtmf.md)
  * [SpeakSentence](bxml/verbs/speakSentence.md)
  * [Transfer](bxml/verbs/transfer.md)
 

--- a/book.json
+++ b/book.json
@@ -6,15 +6,13 @@
         "custom-jquery-postprocessing",
         "bandwidth-toggle-chapters",
         "custom-favicon",
-        "gtm",
         "-hightlight",
         "-fontsettings",
         "bandwidth-highlight",
         "bandwidth-fonts",
         "usabilla",
         "include-html@0.2.0",
-        "codetabs",
-        "mouseflow"
+        "codetabs" 
     ],
     "pluginsConfig": {
         "theme-bandwidth": {
@@ -45,10 +43,6 @@
       "customJquery": {
         "js": "js/custom.js"
       },
-      "gtm": {
-        "token": "GTM-P2JT7Z",
-        "virtualPageViews": true
-      },
       "usabilla" : {
             "usabillaId" : "c590d7d0e7ac"
       },
@@ -69,9 +63,6 @@
             "theme": "white",
             "family": "sans",
             "size": 2
-        },
-        "mouseflow": {
-            "projectId": "e48d3324-5985-479f-a9fc-7283fb266917"
         }
     }
 }

--- a/book.json
+++ b/book.json
@@ -1,6 +1,6 @@
 {
     "plugins": [
-        "theme-bandwidth@1.9.3",
+        "theme-bandwidth@1.9.7",
         "header",
         "sharing",
         "custom-jquery-postprocessing",

--- a/book.json
+++ b/book.json
@@ -1,6 +1,6 @@
 {
     "plugins": [
-        "theme-bandwidth@1.9.7",
+        "theme-bandwidth@1.9.8",
         "header",
         "sharing",
         "custom-jquery-postprocessing",

--- a/bxml/bxml.md
+++ b/bxml/bxml.md
@@ -25,8 +25,10 @@ BXML callbacks perform HTTP GET requests to the **requestUrl** when the notifica
 | [`<Gather>`](verbs/gather.md)               | The Gather verb is used to collect digits for some period of time.                                                                                                                  |
 | [`<Hangup>`](verbs/hangup.md)               | The Hangup verb is used to hangup current call.                                                                                                                                     |
 | [`<PlayAudio>`](verbs/playAudio.md)         | The PlayAudio verb is used to play an audio file in the call.                                                                                                                       |
+| [`<Pause>`](verbs/pause.md)                 | The Pause verb is used to pause the execution of an ongoing BXML document.                                                                                                          |
 | [`<Record>`](verbs/record.md)               | The Record verb allows call recording. At the end of the call, a call recording event containing the media with recorded audio URL is generated                                     |
 | [`<Redirect>`](verbs/redirect.md)           | The Redirect verb is used to redirect the current XML execution to another URL.                                                                                                     |
+| [`<SendDtmf>`](verbs/sendDtmf.md)           | The SendDtmf verb is used to is used to send digits on a live call.                                                                                                                 |
 | [`<SpeakSentence>`](verbs/speakSentence.md) | The SpeakSentence verb is used to convert any text into speak for the caller.                                                                                                       |
 | [`<Transfer>`](verbs/transfer.md)           | The Transfer verb is used to transfer the call to another number.                                                                                                                   |
 

--- a/bxml/verbs/pause.md
+++ b/bxml/verbs/pause.md
@@ -39,16 +39,4 @@ This shows how to use Bandwidth XML to pause before Speaking a Sentence
 </Response>
 ```
 
-## Example: Pause call for 3 hours
-```XML
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-  <Record requestUrl="https://record.url.server/recordVoicemail" transcribe="true" transcribeCallbackUrl="https://transcribe.url/result"/ >
-  <Pause length="3600"/>
-  <Pause length="3600"/>
-  <Pause length="3600"/>
-  <Hangup/>
-</Response>
-```
-
 {% endmethod %}

--- a/bxml/verbs/pause.md
+++ b/bxml/verbs/pause.md
@@ -1,0 +1,54 @@
+{% method %}
+## XML: `<Pause>`
+The `<Pause>` verb is used to pause the execution of an ongoing BXML document.
+
+### Attributes
+| Attribute | Description                                                                                          | Default                         |
+|:----------|:-----------------------------------------------------------------------------------------------------|:--------------------------------|
+| `length`  | The 'length' attribute specifies how many seconds Bandwidth will wait silently before continuing on. | 1 seconds <br><br> Max 3600 seconds |
+
+
+### Callbacks Recevied
+
+| Callback | Can reply with more BXML |
+|:---------|:-------------------------|
+| None     | No                       |
+
+{% common %}
+## Example:  Pause then Speak Sentence
+
+This shows how to use Bandwidth XML to pause before Speaking a Sentence
+
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Response>
+  <Pause length="5"/>
+  <SpeakSentence voice="paola" locale="it" gender="female">Questo è un test</SpeakSentence>
+</Response>
+```
+
+## Example: Simple Pause
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Response>
+  <SpeakSentence voice="susan" gender="female">I will pause 10 seconds starting now!</SpeakSentence>
+  <Pause length="10"/>
+  <SpeakSentence voice="susan" gender="female">I just paused 10 seconds</SpeakSentence>
+</Response>
+```
+
+## Example: Pause call for 3 hours
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Record requestUrl="https://record.url.server/recordVoicemail" transcribe="true" transcribeCallbackUrl="https://transcribe.url/result"/ >
+  <Pause length="3600"/>
+  <Pause length="3600"/>
+  <Pause length="3600"/>
+  <Hangup/>
+</Response>
+```
+
+{% endmethod %}

--- a/bxml/verbs/sendDtmf.md
+++ b/bxml/verbs/sendDtmf.md
@@ -1,0 +1,65 @@
+{% method %}
+## XML: `<SendDtmf>`
+The `<SendDtmf>` element is used to send digits on a live call. This will usually be used to automate the process of navigating through an external phone tree (IVR).
+
+String containing the DTMF characters to be sent in a call. Allows a maximum of 92 characters.[br/]The digits will be sent one-by-one with a marginal delay. - The , and lowercase w characters introduce a half-second pause into the DTMF sequence.[br/]- The W character introduces a one-second pause.[br/]Example: The DTMF string 1WWW,59# will send a 1, wait 3.5 seconds, then send 59# in quick succession.[br/]Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If <SendDtmf> is the last verb in the document then the call will be disconnected 30 seconds after the <SendDtmf> ends.
+
+### Attributes
+| Attribute | Description |
+|:----------|:------------|
+| None      | None        |
+
+### Allowed Values
+
+Maximum of 92 characters.
+
+| Value      | Behavior                            |
+|:-----------|:------------------------------------|
+| `1`        | Will send the button press for: `1` |
+| `2`        | Will send the button press for: `2` |
+| `3`        | Will send the button press for: `3` |
+| `4`        | Will send the button press for: `4` |
+| `5`        | Will send the button press for: `5` |
+| `6`        | Will send the button press for: `6` |
+| `7`        | Will send the button press for: `7` |
+| `8`        | Will send the button press for: `8` |
+| `9`        | Will send the button press for: `9` |
+| `0`        | Will send the button press for: `0` |
+| `*`        | Will send the button press for: `*` |
+| `#`        | Will send the button press for: `#` |
+| `,` or `w` | Will add a 0.5 seconds delay        |
+| `W `       | Will add a 1.0 seconds delay        |
+
+### Callbacks Recevied
+
+| Callback | Can reply with more BXML |
+|:---------|:-------------------------|
+| None     | No                       |
+
+{% common %}
+## Example:  Pause then Send DTMF
+
+This shows how to use Bandwidth XML to pause before sending DTMF button presses.
+
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Response>
+  <Pause length="5"/>
+  <DTMF>1234</DTMF>
+</Response>
+```
+
+## Example: Send digits with a 2.5 second delay
+
+This shows how to use Bandwidth XML to pause 2.5 seconds between sending the 1 and 234 button presses.
+
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Response>
+  <DTMF>1WW,234</DTMF>
+</Response>
+```
+
+{% endmethod %}

--- a/bxml/verbs/sendDtmf.md
+++ b/bxml/verbs/sendDtmf.md
@@ -5,10 +5,10 @@ The `<SendDtmf>` element is used to send digits on a live call. This will usuall
 String containing the DTMF characters to be sent in a call. **Allows a maximum of 92 characters.**
 The digits will be sent one-by-one with a marginal delay. 
 
-- The , and lowercase w characters introduce a half-second pause into the DTMF sequence. 
-- The W character introduces a one-second pause. 
+- The `,` and lowercase `w` characters introduce a half-second pause into the DTMF sequence. 
+- The uppercase `W` character introduces a one-second pause. 
 
-Example: The DTMF string 1WWW,59# will send a 1, wait 3.5 seconds, then send 59# in quick succession.
+Example: The DTMF string '1WWW,59#'' will send a 1, wait 3.5 seconds, then send 59# in quick succession.
 Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If <SendDtmf> is the last verb in the document then the call will be disconnected 30 seconds after the <SendDtmf> ends.
 
 ### Attributes

--- a/bxml/verbs/sendDtmf.md
+++ b/bxml/verbs/sendDtmf.md
@@ -10,7 +10,7 @@ The digits will be sent one-by-one with a marginal delay.
 
 Example: The DTMF string '1WWW,59#'' will send a 1, wait 3.5 seconds, then send 59# in quick succession.
 
-Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If <SendDtmf> is the last verb in the document then the call will be disconnected 30 seconds after the <SendDtmf> ends.
+Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If `<SendDtmf>` is the last verb in the document then the call will be disconnected 30 seconds after the `<SendDtmf>` ends.
 
 ### Attributes
 | Attribute | Description |

--- a/bxml/verbs/sendDtmf.md
+++ b/bxml/verbs/sendDtmf.md
@@ -2,7 +2,14 @@
 ## XML: `<SendDtmf>`
 The `<SendDtmf>` element is used to send digits on a live call. This will usually be used to automate the process of navigating through an external phone tree (IVR).
 
-String containing the DTMF characters to be sent in a call. Allows a maximum of 92 characters.[br/]The digits will be sent one-by-one with a marginal delay. - The , and lowercase w characters introduce a half-second pause into the DTMF sequence.[br/]- The W character introduces a one-second pause.[br/]Example: The DTMF string 1WWW,59# will send a 1, wait 3.5 seconds, then send 59# in quick succession.[br/]Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If <SendDtmf> is the last verb in the document then the call will be disconnected 30 seconds after the <SendDtmf> ends.
+String containing the DTMF characters to be sent in a call. **Allows a maximum of 92 characters.**
+The digits will be sent one-by-one with a marginal delay. 
+
+- The , and lowercase w characters introduce a half-second pause into the DTMF sequence. 
+- The W character introduces a one-second pause. 
+
+Example: The DTMF string 1WWW,59# will send a 1, wait 3.5 seconds, then send 59# in quick succession.
+Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If <SendDtmf> is the last verb in the document then the call will be disconnected 30 seconds after the <SendDtmf> ends.
 
 ### Attributes
 | Attribute | Description |
@@ -46,7 +53,7 @@ This shows how to use Bandwidth XML to pause before sending DTMF button presses.
 
 <Response>
   <Pause length="5"/>
-  <DTMF>1234</DTMF>
+  <SendDtmf>1234</SendDtmf>
 </Response>
 ```
 
@@ -58,7 +65,7 @@ This shows how to use Bandwidth XML to pause 2.5 seconds between sending the 1 a
 <?xml version="1.0" encoding="UTF-8"?>
 
 <Response>
-  <DTMF>1WW,234</DTMF>
+  <SendDtmf>1WW,234</SendDtmf>
 </Response>
 ```
 

--- a/bxml/verbs/sendDtmf.md
+++ b/bxml/verbs/sendDtmf.md
@@ -9,6 +9,7 @@ The digits will be sent one-by-one with a marginal delay.
 - The uppercase `W` character introduces a one-second pause. 
 
 Example: The DTMF string '1WWW,59#'' will send a 1, wait 3.5 seconds, then send 59# in quick succession.
+
 Example: The DTMF string '1Ww2Ww1Ww#' will send a '1', then '2', then '1', then '#' with a wait time of 1.5 seconds between each character sent. If <SendDtmf> is the last verb in the document then the call will be disconnected 30 seconds after the <SendDtmf> ends.
 
 ### Attributes


### PR DESCRIPTION
## For the Committer

- [x] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [x] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
