### PR TITLE
Fixed get sms callback examples

### DIFF
--- a/apiCallbacks/audio.md
+++ b/apiCallbacks/audio.md
@@ -55,7 +55,7 @@ POST http://[External server URL]
    "eventType":"playback",
    "callId":"{callId}",
    "callUri": "https://api.catapult.inetwork.com/v1/users/{userId}/calls/{callId}",
-   "status":"started",
+   "status":"done",
    "time":"2012-11-14T15:56:05.896Z"
 }
 ```

--- a/apiCallbacks/get-mms.md
+++ b/apiCallbacks/get-mms.md
@@ -1,36 +1,72 @@
 {% method %}
-## Incoming MMS event
+## MMS Event
+Events sent to your server for inbound and outbound MMS messages.
 
 ### Properties
-| Property   | Description                                                                                                                                                                                                                                   |
-|:-----------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| eventType  | The event type, value is `mms`.                                                                                                                                                                                                               |
-| direction  | Direction of message: <br> `in` - a message that came from the telephone network to one of your numbers (an “inbound” message) |
-| from       | The message sender’s telephone number (or short code).                                                                                                                                                                                        |
-| to         | Message recipient telephone number (or short code).                                                                                                                                                                                           |
-| messageId  | The unique id of the message resource for this event.                                                                                                                                                                                         |
-| messageUri | The full URL of the message resource.                                                                                                                                                                                                         |
-| media | The full URLs of any media attached the the message
-| text       | The message contents.                                                                                                                                                                                                                         |
-| time       | The time the message resource was created (UTC, follows the ISO 8601 format).                                                                                                                                                                 |
-| state      | Message state, values are `received` `queued` `sending` `sent` `error`                                                                                                                                                                        |
+| PROPERTY            | DESCRIPTION                                                                                                                                                                                                                                  |
+|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| eventType           | The event type, value is `mms`.                                                                                                                                                                                                              |
+| direction           | Direction of message<br> * `in` - a message that came from the telephone network to one of your numbers (an “inbound” message)<br>*`out` - a message that was sent from one of your numbers to the telephone network (an “outbound” message) |
+| from                | The message sender’s telephone number (or short code).                                                                                                                                                                                       |
+| to                  | Message recipient telephone number (or short code).                                                                                                                                                                                          |
+| messageId           | The unique id of the message resource for this event.                                                                                                                                                                                        |
+| messageUri          | The full URL of the message resource.                                                                                                                                                                                                        |
+| text                | The message contents.                                                                                                                                                                                                                        |
+| applicationId       | The application id associated with the phone number receiving the inbound messages.                                                                                                                                                          |
+| time                | The time the message resource was created (UTC, follows the ISO 8601 format).                                                                                                                                                                |
+| state               | Message state, values are `received`                                                                                                                                                                                                         |
+| media               | URIs of media files associate with the MMS message.                                                                                                                                                                                          |
+| deliveryState       | Delivery state of the message--present only sometimes, to indicate certain errors                                                                                                                                                            |
+| deliveryCode        | Numerical code indicating the delivery status of the message--present only sometimes, to indicate certain errors                                                                                                                             |
+| deliveryDescription | Human-readable description of the delivery status--present only sometimes, to indicate certain errors                                                                                                                                  |
 
 {% common %}
-#### HTTP request sent to the <code class="get">incomingMessageUrl</code>  configured in the [application](../methods/applications/applications.md):
 
-```html
-/{callbackUrl}?
-	messageId=m-asdf&
-	from=%2B19191231111&
-	eventType=mms&
-	text=test&
-	time=2016-12-01T16:04:49Z&
-	to=%2B13204601164&
-	state=received&
-	applicationId=a-yr3jpxasdfh5xh5e35saoi&
-	direction=in&
-	media=[{full-url}/giphy-m-asdf.gif, {full-url}/123_1-m-asdf.smil]
-	messageUri=https%3A%2F%2Fapi.catapult.inetwork.com%2Fv1%2Fusers%2Fu-123%2Fmessages%2Fm-asdf
+#### Example JSON
+
+
+```json
+{
+  "eventType"           : "string",
+  "direction"           : "string",
+  "from"                : "string",
+  "to"                  : "string",
+  "messageId"           : "string",
+  "messageUri"          : "string",
+  "text"                : "string",
+  "applicationId"       : "string",
+  "time"                : "date",
+  "state"               : "string",
+  "deliveryState"       : "string",
+  "deliveryCode"        : "string",
+  "deliveryDescription" : "string",
+  "media"               : ["mediaUri1", "mediaUri2"...]
+}
 ```
 
+{% common %}
+#### Example: Inbound MMS
+
+```
+GET http://[External server URL]
+```
+
+```json
+{
+   "eventType"     : "mms",
+   "to"            : "+12534483100",
+   "from"          : "+15035555555",
+   "time"          : "2015-08-04T21:50:12Z",
+   "text"          : "Hello MMS!",
+   "direction"     : "in",
+   "applicationId" : "a-rj7jf3fz7teaqupveqpug3i",
+   "state"         : "received",
+   "messageId"     : "m-dr4mcch2wfb6frcls677glq",
+   "media"         : [
+      "https://api.catapult.inetwork.com/v1/users/{user-id}/media/A3087419-73C2-4A03-BB39-06BF3B1C240F-m-dr4mcch2wfb6frcls677glq.jpg",
+      "https://api.catapult.inetwork.com/v1/users/{user-id}/media/123_1-m-dr4mcch2wfb6frcls677glq.smil"
+      ],
+    "messageUri"   : "https://api.catapult.inetwork.com/v1/users/{user-id}/messages/m-dr4mcch2wfb6frcls677glq"
+}
+```
 {% endmethod %}

--- a/apiCallbacks/get-mms.md
+++ b/apiCallbacks/get-mms.md
@@ -22,29 +22,6 @@ Events sent to your server for inbound and outbound MMS messages.
 
 {% common %}
 
-#### Example JSON
-
-
-```json
-{
-  "eventType"           : "string",
-  "direction"           : "string",
-  "from"                : "string",
-  "to"                  : "string",
-  "messageId"           : "string",
-  "messageUri"          : "string",
-  "text"                : "string",
-  "applicationId"       : "string",
-  "time"                : "date",
-  "state"               : "string",
-  "deliveryState"       : "string",
-  "deliveryCode"        : "string",
-  "deliveryDescription" : "string",
-  "media"               : ["mediaUri1", "mediaUri2"...]
-}
-```
-
-{% common %}
 #### Example: Inbound MMS
 
 ```

--- a/apiCallbacks/get-sms.md
+++ b/apiCallbacks/get-sms.md
@@ -60,28 +60,6 @@ Bandwidth API sends this event to the application when an SMS is sent or receive
 
 {% common %}
 
-#### Example JSON
-
-
-```json
-{
-  "eventType"           : "string",
-  "direction"           : "string",
-  "from"                : "string",
-  "to"                  : "string",
-  "messageId"           : "string",
-  "messageUri"          : "string",
-  "text"                : "string",
-  "applicationId"       : "string",
-  "time"                : "date",
-  "state"               : "string",
-  "deliveryState"       : "string",
-  "deliveryCode"        : "string",
-  "deliveryDescription" : "string"
-}
-```
-
-
 #### Example: Incoming SMS Event
 
 ```http

--- a/apiCallbacks/get-sms.md
+++ b/apiCallbacks/get-sms.md
@@ -1,34 +1,145 @@
 {% method %}
-## Incoming SMS event
+## SMS Event
+Bandwidth API sends this event to the application when an SMS is sent or received.
 
 ### Properties
-| Property   | Description                                                                                                                                                                                                                                   |
-|:-----------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| eventType  | The event type, value is `sms`.                                                                                                                                                                                                               |
-| direction  | Direction of message: <br> `in` - a message that came from the telephone network to one of your numbers (an “inbound” message) <br> `out` - a message that was sent from one of your numbers to the telephone network (an “outbound” message) |
-| from       | The message sender’s telephone number (or short code).                                                                                                                                                                                        |
-| to         | Message recipient telephone number (or short code).                                                                                                                                                                                           |
-| messageId  | The unique id of the message resource for this event.                                                                                                                                                                                         |
-| messageUri | The full URL of the message resource.                                                                                                                                                                                                         |
-| text       | The message contents.                                                                                                                                                                                                                         |
-| time       | The time the message resource was created (UTC, follows the ISO 8601 format).                                                                                                                                                                 |
-| state      | Message state, values are `received` `queued` `sending` `sent` `error`                                                                                                                                                                        |
+| Property            | Description                                                                                                                                                                                                                                      |
+|:--------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| eventType           | The event type, value is `sms`.                                                                                                                                                                                                                  |
+| direction           | Direction of message, <br>* `in` - a message that came from the telephone network to one of your numbers (an “inbound” message) <br> * `out` - a message that was sent from one of your numbers to the telephone network (an “outbound” message) |
+| from                | The message sender’s telephone number (or short code).                                                                                                                                                                                           |
+| to                  | Message recipient telephone number (or short code).                                                                                                                                                                                              |
+| messageId           | The unique id of the message resource for this event.                                                                                                                                                                                            |
+| messageUri          | The full URL of the message resource.                                                                                                                                                                                                            |
+| text                | The message’s text contents.                                                                                                                                                                                                                     |
+| applicationId       | The application id associated with the phone number receiving the inbound message.                                                                                                                                                               |
+| time                | The time the message resource was created (UTC, follows the ISO 8601 format).                                                                                                                                                                    |
+| state               | Message state, values are received queued sending sent error                                                                                                                                                                                     |
+| deliveryState       | One of the message delivery states `waiting` `delivered` `not-delivered`                                                                                                                                                                         |
+| deliveryCode        | Numeric value of deliver code                                                                                                                                                                        |
+| deliveryDescription | Message delivery description for the respective delivery code.                                                                                                                                                                                   |
+
+### Message States
+| State    | Description                                                                            |
+|:---------|:---------------------------------------------------------------------------------------|
+| received | The message was received.                                                              |
+| queued   | The message is waiting in queue and will be sent soon.                                 |
+| sending  | The message was removed from queue and is being sent.                                  |
+| sent     | The message was sent successfully.                                                     |
+| error    | There was an error sending or receiving a message (check errors resource for details). |
+
+### Message Delivery State
+| State         | Description                                        |
+|:--------------|:---------------------------------------------------|
+| waiting       | Waiting for receipt.                               |
+| delivered     | Receipt indicating that message was delivered.     |
+| not-delivered | Receipt indicating that message was not delivered. |
+
+### Message Delivery Code
+| Code | Description                                   |
+|:-----|:----------------------------------------------|
+| 0    | Message delivered to carrier                  |
+| 100  | Message not delivered to carrier              |
+| 187  | Statistical spam detected                     |
+| 188  | Keyword spam detected                         |
+| 189  | Spam detected                                 |
+| 482  | Loop detected                                 |
+| 600  | Destination carrier could not accept messages |
+| 610  | Message submittion failed                     |
+| 620  | Destination application error                 |
+| 630  | Message not acknowledge                       |
+| 650  | Destination Failure                           |
+| 720  | Invalid destination number                    |
+| 740  | Invalid source number                         |
+| 750  | Destination Rejected Message                  |
+| 751  | Destination Rejected Message too large        |
+| 770  | Destination Rejected due to SPAM              |
+| 775  | Rejected due to user opt out                  |
+| 902  | Message Expired                               |
+| 999  | Unknown error                                 |
 
 {% common %}
-#### HTTP request sent to the <code class="get">incomingMessageUrl</code> configured in the [application](../methods/applications/applications.md):
 
-```html
-/{callbackUrl}?
-	messageId=m-asdf&
-	from=%2B19191231111&
-	eventType=sms&
-	text=test&
-	time=2016-12-01T16:04:49Z&
-	to=%2B13204601164&
-	state=received&
-	applicationId=a-yr3jpxasdfh5xh5e35saoi&
-	direction=in&
-	messageUri=https%3A%2F%2Fapi.catapult.inetwork.com%2Fv1%2Fusers%2Fu-123%2Fmessages%2Fm-asdf
+#### Example JSON
+
+
+```json
+{
+  "eventType"           : "string",
+  "direction"           : "string",
+  "from"                : "string",
+  "to"                  : "string",
+  "messageId"           : "string",
+  "messageUri"          : "string",
+  "text"                : "string",
+  "applicationId"       : "string",
+  "time"                : "date",
+  "state"               : "string",
+  "deliveryState"       : "string",
+  "deliveryCode"        : "string",
+  "deliveryDescription" : "string"
+}
 ```
 
+
+#### Example: Incoming SMS Event
+
+```http
+GET /your_url HTTP/1.1
+Content-Type: application/json; charset=utf-8
+User-Agent: BandwidthAPI/v1
+
+{
+ "eventType"     : "sms",
+ "direction"     : "in",
+ "messageId"     : "{messageId}",
+ "messageUri"    : "https://api.catapult.inetwork.com/v1/users/{userId}/messages/{messageId}",
+ "from"          : "+13233326955",
+ "to"            : "+13865245000",
+ "text"          : "Example",
+ "applicationId" : "{appId}",
+ "time"          : "2012-11-14T16:13:06.076Z",
+ "state"         : "received"
+}
+```
+
+#### Example: Outgoing SMS Event
+
+```http
+GET /your_url HTTP/1.1
+Content-Type: application/json; charset=utf-8
+User-Agent: BandwidthAPI/v1
+
+{
+   "eventType"  : "sms",
+   "direction"  : "out",
+   "messageId"  : "{messageId}",
+   "messageUri" : "https://api.catapult.inetwork.com/v1/users/{userId}/messages/{messageId}",
+   "from"       : "+13233326955",
+   "to"         : "+13865245000",
+   "text"       : "Example",
+   "time"       : "2012-11-14T16:13:06.076Z",
+   "state"      : "sent"
+}
+```
+#### Example: Outgoing SMS with Delivery Request Event
+
+```http
+GET /your_url HTTP/1.1
+Content-Type: application/json; charset=utf-8
+User-Agent: BandwidthAPI/v1
+
+{
+   "eventType"     : "sms",
+   "direction"     : "in",
+   "messageId"     : "{messageId}",
+   "messageUri"    : "https://api.catapult.inetwork.com/v1/users/{userId}/messages/{messageId}",
+   "from"          : "+13233326955",
+   "to"            : "+13865245000",
+   "text"          : "Example",
+   "applicationId" : "{appId}",
+   "time"          : "2012-11-14T16:13:06.076Z",
+   "state"         : "received"
+}
+```
 {% endmethod %}


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
