### PR TITLE
Added template for diversion header

### DIFF
--- a/apiCallbacks/answer.md
+++ b/apiCallbacks/answer.md
@@ -13,6 +13,14 @@ Bandwidth API sends this message to the application when the call is answered.
 | callUri   | The full URL of the call resource for this event.                                                                                                            |
 | tag       | String provided when call created.                                                                                                                           |
 | time      | Date when the event occurred. Timestamp follows the ISO8601 format (UTC).                                                                                    |
+| diversion | Diversion information if present |
+| diversion.origTo | The parameter value as received in the header |
+| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>A</li><li>B</li></ul>|
+| diversion.screen | The parameter value as received in the header |
+| diversion.privacy | The parameter value as received in the header |
+| diversion.counter| The parameter value as received in the header |
+| diversion.Limit | The parameter value as received in the header |
+| diversion.name| The parameter value as received in the header |
 
 {% common %}
 
@@ -26,7 +34,16 @@ Bandwidth API sends this message to the application when the call is answered.
 	"callId"    : "string",
 	"callUri"   : "string",
 	"callState" : "string",
-	"time"      : "date"
+	"time"      : "date",
+    "diversion": {
+        "origTo" : "string",
+        "reason" : "string",
+        "screen" : "string",
+        "privacy": "string",
+        "counter": "integer",
+        "Limit"  : "integer",
+        "name"   : "string"
+    }
 }
 ```
 

--- a/apiCallbacks/answer.md
+++ b/apiCallbacks/answer.md
@@ -14,13 +14,13 @@ Bandwidth API sends this message to the application when the call is answered.
 | tag       | String provided when call created.                                                                                                                           |
 | time      | Date when the event occurred. Timestamp follows the ISO8601 format (UTC).                                                                                    |
 | diversion | Diversion information if present |
-| diversion.origTo | The parameter value as received in the header |
+| diversion.origTo | The last E.164 telephone number that the call was diverted from. |
 | diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>unknown</li><li>user-busy</li><li>no-answer</li><li>unavailable</li><li>unconditional</li><li>time-of-day</li><li>do-not-disturb</li><li>deflection</li><li>follow-me</li><li>out-of-service</li><li>away</li></ul>|
-| diversion.screen | The parameter value as received in the header |
-| diversion.privacy | The parameter value as received in the header |
-| diversion.counter| The parameter value as received in the header |
-| diversion.Limit | The parameter value as received in the header |
-| diversion.name| The parameter value as received in the header |
+| diversion.screen | "no" if the number is user provided, "yes" if the number is network provided. |
+| diversion.privacy | "off" or "full". If "full", origTo is set to "Anonymous". |
+| diversion.counter| Number of diversions. |
+| diversion.limit | Max number of diversions allowed. |
+| diversion.{name}| Additional name-value pairs that are in the diversion header. |
 
 {% common %}
 
@@ -36,13 +36,13 @@ Bandwidth API sends this message to the application when the call is answered.
 	"callState" : "string",
 	"time"      : "date",
     "diversion": {
-        "origTo" : "string",
-        "reason" : "string",
-        "screen" : "string",
-        "privacy": "string",
-        "counter": "integer",
-        "Limit"  : "integer",
-        "name"   : "string"
+        "origTo"   : "string",
+        "reason"   : "string",
+        "screen"   : "string",
+        "privacy"  : "string",
+        "counter"  : "integer",
+        "limit"    : "integer",
+        "{name}"   : "{value}"
     }
 }
 ```

--- a/apiCallbacks/answer.md
+++ b/apiCallbacks/answer.md
@@ -15,7 +15,7 @@ Bandwidth API sends this message to the application when the call is answered.
 | time      | Date when the event occurred. Timestamp follows the ISO8601 format (UTC).                                                                                    |
 | diversion | Diversion information if present |
 | diversion.origTo | The parameter value as received in the header |
-| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>A</li><li>B</li></ul>|
+| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>unknown</li><li>user-busy</li><li>no-answer</li><li>unavailable</li><li>unconditional</li><li>time-of-day</li><li>do-not-disturb</li><li>deflection</li><li>follow-me</li><li>out-of-service</li><li>away</li></ul>|
 | diversion.screen | The parameter value as received in the header |
 | diversion.privacy | The parameter value as received in the header |
 | diversion.counter| The parameter value as received in the header |

--- a/apiCallbacks/incomingCall.md
+++ b/apiCallbacks/incomingCall.md
@@ -14,6 +14,14 @@ Bandwidth API sends this message to the application when an incoming call arrive
 | callState     | The state of the call, value is active.                                                                                                                      |
 | applicationId | The id of the application associated with phone number for this this incoming call.                                                                          |
 | time          | Date/time of event. Timestamp follows the ISO8601 format (UTC).                                                                                              |
+| diversion | Diversion information if present |
+| diversion.origTo | The parameter value as received in the header |
+| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>A</li><li>B</li></ul>|
+| diversion.screen | The parameter value as received in the header |
+| diversion.privacy | The parameter value as received in the header |
+| diversion.counter| The parameter value as received in the header |
+| diversion.Limit | The parameter value as received in the header |
+| diversion.name| The parameter value as received in the header |
 
 {% common %}
 
@@ -29,7 +37,16 @@ Bandwidth API sends this message to the application when an incoming call arrive
   "callUri"       : "string",
   "callState"     : "string",
   "applicationId" : "string",
-  "time"          : "date"
+  "time"          : "date",
+  "diversion": {
+      "origTo" : "string",
+      "reason" : "string",
+      "screen" : "string",
+      "privacy": "string",
+      "counter": "integer",
+      "Limit"  : "integer",
+      "name"   : "string"
+  }
 }
 ```
 

--- a/apiCallbacks/incomingCall.md
+++ b/apiCallbacks/incomingCall.md
@@ -15,13 +15,13 @@ Bandwidth API sends this message to the application when an incoming call arrive
 | applicationId | The id of the application associated with phone number for this this incoming call.                                                                          |
 | time          | Date/time of event. Timestamp follows the ISO8601 format (UTC).                                                                                              |
 | diversion | Diversion information if present |
-| diversion.origTo | The parameter value as received in the header |
+| diversion.origTo | The last E.164 telephone number that the call was diverted from. |
 | diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>unknown</li><li>user-busy</li><li>no-answer</li><li>unavailable</li><li>unconditional</li><li>time-of-day</li><li>do-not-disturb</li><li>deflection</li><li>follow-me</li><li>out-of-service</li><li>away</li></ul>|
-| diversion.screen | The parameter value as received in the header |
-| diversion.privacy | The parameter value as received in the header |
-| diversion.counter| The parameter value as received in the header |
-| diversion.Limit | The parameter value as received in the header |
-| diversion.name| The parameter value as received in the header |
+| diversion.screen | "no" if the number is user provided, "yes" if the number is network provided. |
+| diversion.privacy | "off" or "full". If "full", origTo is set to "Anonymous". |
+| diversion.counter| Number of diversions. |
+| diversion.limit | Max number of diversions allowed. |
+| diversion.{name}| Additional name-value pairs that are in the diversion header. |
 
 {% common %}
 
@@ -30,23 +30,23 @@ Bandwidth API sends this message to the application when an incoming call arrive
 
 ```json
 {
-  "eventType"     : "string",
-  "from"          : "string",
-  "to"            : "string",
-  "callId"        : "string",
-  "callUri"       : "string",
-  "callState"     : "string",
-  "applicationId" : "string",
-  "time"          : "date",
-  "diversion": {
-      "origTo" : "string",
-      "reason" : "string",
-      "screen" : "string",
-      "privacy": "string",
-      "counter": "integer",
-      "Limit"  : "integer",
-      "name"   : "string"
-  }
+    "eventType"     : "string",
+    "from"          : "string",
+    "to"            : "string",
+    "callId"        : "string",
+    "callUri"       : "string",
+    "callState"     : "string",
+    "applicationId" : "string",
+    "time"          : "date",
+    "diversion": {
+        "origTo"   : "string",
+        "reason"   : "string",
+        "screen"   : "string",
+        "privacy"  : "string",
+        "counter"  : "integer",
+        "limit"    : "integer",
+        "{name}"   : "{value}"
+    }
 }
 ```
 

--- a/apiCallbacks/incomingCall.md
+++ b/apiCallbacks/incomingCall.md
@@ -16,7 +16,7 @@ Bandwidth API sends this message to the application when an incoming call arrive
 | time          | Date/time of event. Timestamp follows the ISO8601 format (UTC).                                                                                              |
 | diversion | Diversion information if present |
 | diversion.origTo | The parameter value as received in the header |
-| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>A</li><li>B</li></ul>|
+| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>unknown</li><li>user-busy</li><li>no-answer</li><li>unavailable</li><li>unconditional</li><li>time-of-day</li><li>do-not-disturb</li><li>deflection</li><li>follow-me</li><li>out-of-service</li><li>away</li></ul>|
 | diversion.screen | The parameter value as received in the header |
 | diversion.privacy | The parameter value as received in the header |
 | diversion.counter| The parameter value as received in the header |

--- a/bxml/callBacks/answer.md
+++ b/bxml/callBacks/answer.md
@@ -12,6 +12,14 @@
 | callUri   | The full URL of the call resource for this event.                                                                                                                                                                       |
 | time      | Date when the event occurred. Timestamp follows the ISO8601 format (UTC).                                                                                                                                               |
 | tag       | String provided when call created. <br> <br> **Only sent as query parameter if the call was [created](../../methods/calls/postCalls.md) with a tag**.  <br>  An answer event on an incoming call, will never have a tag |
+| diversion | Diversion information if present |
+| diversion.origTo | The last E.164 telephone number that the call was diverted from. |
+| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>unknown</li><li>user-busy</li><li>no-answer</li><li>unavailable</li><li>unconditional</li><li>time-of-day</li><li>do-not-disturb</li><li>deflection</li><li>follow-me</li><li>out-of-service</li><li>away</li></ul>|
+| diversion.screen | "no" if the number is user provided, "yes" if the number is network provided. |
+| diversion.privacy | "off" or "full". If "full", origTo is set to "Anonymous". |
+| diversion.counter| Number of diversions. |
+| diversion.limit | Max number of diversions allowed. |
+| diversion.{name}| Additional name-value pairs that are in the diversion header. |
 
 
 {% common %}

--- a/bxml/callBacks/incomingCall.md
+++ b/bxml/callBacks/incomingCall.md
@@ -15,6 +15,14 @@ When your account is configured to use BXML, by setting the [application](../../
 | callId    | The call id associated with the event.                                                                                                                       |
 | callUri   | The full URL of the call resource for this event.                                                                                                            |
 | time      | Date when the event occurred. Timestamp follows the ISO8601 format (UTC).                                                                                    |
+| diversion | Diversion information if present |
+| diversion.origTo | The last E.164 telephone number that the call was diverted from. |
+| diversion.reason | Reason for the diversion. Must be one of the following:<br><ul><li>unknown</li><li>user-busy</li><li>no-answer</li><li>unavailable</li><li>unconditional</li><li>time-of-day</li><li>do-not-disturb</li><li>deflection</li><li>follow-me</li><li>out-of-service</li><li>away</li></ul>|
+| diversion.screen | "no" if the number is user provided, "yes" if the number is network provided. |
+| diversion.privacy | "off" or "full". If "full", origTo is set to "Anonymous". |
+| diversion.counter| Number of diversions. |
+| diversion.limit | Max number of diversions allowed. |
+| diversion.{name}| Additional name-value pairs that are in the diversion header. |
 
 {% common %}
 #### HTTP request sent to the callback url


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
