### PR TITLE
Fixed wrong usage of "it's"

### DIFF
--- a/methods/phoneNumbers/getPhoneNumbers.md
+++ b/methods/phoneNumbers/getPhoneNumbers.md
@@ -16,8 +16,8 @@ Gets a list of your numbers. Since this operation uses HTTP GET, all the propert
 | size          | Used for pagination to indicate the size of each page requested for querying a list of phone numbers. If no value is specified the default value is 25. (Maximum value 1000) | No        |
 | applicationId | Used to filter the retrieved list of numbers by an associated application ID.                                                                                                | No        |
 | state         | Used to filter the retrieved list of numbers allocated for the authenticated user by a US state.                                                                             | No        |
-| name          | Used to filter the retrieved list of numbers allocated for the authenticated user by it’s name.                                                                              | No        |
-| city          | Used to filter the retrieved list of numbers allocated for the authenticated user by it’s city.                                                                              | No        |
+| name          | Used to filter the retrieved list of numbers allocated for the authenticated user by its name.                                                                              | No        |
+| city          | Used to filter the retrieved list of numbers allocated for the authenticated user by its city.                                                                              | No        |
 | numberState   | Used to filter the retrieved list of numbers allocated for the authenticated user by the number state.                                                                       | No        |
 
 ### Properties


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
