### PR TITLE
Added JSON doc to get toll free numbers page

### DIFF
--- a/methods/availableNumbers/getAvailableNumbersTollFree.md
+++ b/methods/availableNumbers/getAvailableNumbersTollFree.md
@@ -1,6 +1,5 @@
 {% method %}
-## List available toll free numbers
-
+## List available toll-free numbers
 For more information about Bandwidth’s toll free phone numbers, see the <a href="https://dev.bandwidth.com/faq/#voice">FAQ</a>. To learn more about MMS on toll-free numbers, see the [FAQ](https://dev.bandwidth.com/faq/messaging/tollfreeMMS.html).
 
 
@@ -17,6 +16,15 @@ For more information about Bandwidth’s toll free phone numbers, see the <a hre
 |:----------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
 | quantity  | The maximum number of numbers to return (default 10, maximum 5000).                                                                                                                                                                        | No        |
 | pattern   | A number pattern that may include letters, digits, and the following wildcard characters:<br> - `?` : matches any single digit<br> - `*` : matches zero or more digits<br>Don’t forget to encode wildcard characters in the requested URL. | No        |
+
+## Properties
+| Property       | Description                                                                                                   
+|:---------------|:--------------------------------------------------------------------------------------------------------------
+| number         | The telephone number in E.164 format.                                                                         
+| nationalNumber | The telephone number in a friendly national format.                                                           
+| patternMatch   | The telephone number in a friendly national format with some numbers replaced by letters if a pattern was used
+| price          | The monthly price for the phone number.
+
 
 {% common %}
 ### Example 1 of 1: Search and allocate tollFree number
@@ -77,7 +85,7 @@ results = AvailableNumber.search_toll_free(client, {
 first_result = results.next
 first_number = first_result[:number]
 ```
-
+{% common %}
 > The above command returns JSON structured like this:
 
 ```json


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
