### PR TITLE
Fix missing bxml verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Before you can make your first API Request, you will need to [Sign up](https://c
 | [Speak Event](apiCallbacks/speak.md)                              | Bandwidth API sends this message to the application when text-to-speech starts or stops.                                                                                                                  |
 | [Transcription Event – BETA](apiCallbacks/transcription.md)       | Bandwidth API sends this event to the application when a transcription is terminated or an error occurs while processing it.                                                                              |
 
-### BXMLVerbs
+## BXML Verbs
 
 | Verb                                        | Description                                                                                                                                                                         |
 |:--------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -69,7 +69,7 @@ Before you can make your first API Request, you will need to [Sign up](https://c
 | [`<SpeakSentence>`](verbs/speakSentence.md) | The SpeakSentence verb is used to convert any text into speak for the caller.                                                                                                       |
 | [`<Transfer>`](verbs/transfer.md)           | The Transfer verb is used to transfer the call to another number.                                                                                                                   |
 
-### BXML Callbacks
+## BXML Callbacks
 
 BXML events are HTTP messages that are sent to your application server to notify you of activity related to your Bandwidth resources during a BXML usage.
 

--- a/README.md
+++ b/README.md
@@ -55,29 +55,33 @@ Before you can make your first API Request, you will need to [Sign up](https://c
 | [Speak Event](apiCallbacks/speak.md)                              | Bandwidth API sends this message to the application when text-to-speech starts or stops.                                                                                                                  |
 | [Transcription Event – BETA](apiCallbacks/transcription.md)       | Bandwidth API sends this event to the application when a transcription is terminated or an error occurs while processing it.                                                                              |
 
-## BXML verbs
+### BXMLVerbs
 
-| Verb                                             | Description                                                                                                                                     |
-|:-------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`<Gather>`](bxml/verbs/gather.md)               | The Gather verb is used to collect digits for some period of time.                                                                              |
-| [`<Hangup>`](bxml/verbs/hangup.md)               | The Hangup verb is used to hangup current call.                                                                                                 |
-| [`<PlayAudio>`](bxml/verbs/playAudio.md)         | The PlayAudio verb is used to play an audio file in the call.                                                                                   |
-| [`<Record>`](bxml/verbs/record.md)               | The Record verb allows call recording. At the end of the call, a call recording event containing the media with recorded audio URL is generated |
-| [`<Redirect>`](bxml/verbs/redirect.md)           | The Redirect verb is used to redirect the current XML execution to another URL.                                                                 |
-| [`<SpeakSentence>`](bxml/verbs/speakSentence.md) | The SpeakSentence verb is used to convert any text into speak for the caller.                                                                   |
-| [`<Transfer>`](bxml/verbs/transfer.md)           | The Transfer verb is used to transfer the call to another number.                                                                               |
+| Verb                                        | Description                                                                                                                                                                         |
+|:--------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`<Gather>`](verbs/gather.md)               | The Gather verb is used to collect digits for some period of time.                                                                                                                  |
+| [`<Hangup>`](verbs/hangup.md)               | The Hangup verb is used to hangup current call.                                                                                                                                     |
+| [`<PlayAudio>`](verbs/playAudio.md)         | The PlayAudio verb is used to play an audio file in the call.                                                                                                                       |
+| [`<Pause>`](verbs/pause.md)                 | The Pause verb is used to pause the execution of an ongoing BXML document.                                                                                                          |
+| [`<Record>`](verbs/record.md)               | The Record verb allows call recording. At the end of the call, a call recording event containing the media with recorded audio URL is generated                                     |
+| [`<Redirect>`](verbs/redirect.md)           | The Redirect verb is used to redirect the current XML execution to another URL.                                                                                                     |
+| [`<SendDtmf>`](verbs/sendDtmf.md)           | The SendDtmf verb is used to is used to send digits on a live call.                                                                                                                 |
+| [`<SpeakSentence>`](verbs/speakSentence.md) | The SpeakSentence verb is used to convert any text into speak for the caller.                                                                                                       |
+| [`<Transfer>`](verbs/transfer.md)           | The Transfer verb is used to transfer the call to another number.                                                                                                                   |
 
-## BXML Callbacks
+### BXML Callbacks
 
-| Event                                                  | Description                                                                                                                     |
-|:-------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
-| [Answer Event](bxml/callBacks/answer.md)               | Bandwidth API sends this message to the application when the call is answered.                                                  |
-| [Gather event](bxml/callBacks/gather.md)               | Bandwidth API generates a gather event when the gather command completes in a call.                                             |
-| [Hangup Event](bxml/callBacks/hangup.md)               | Bandwidth API sends this message to the application when the call ends.                                                         |
-| [Recording event](bxml/callBacks/recording.md)         | Bandwidth API sends this event to the application when an the recording media file is saved or an error occurs while saving it. |
-| [Transcription event](bxml/callBacks/transcription.md) | Bandwidth API sends this event to the application when the recording media file is transcribed if requested.                    |
-| [Redirect event](bxml/callBacks/redirect.md)           | Bandwidth API sends this event to the application when a `<Redirect>` is requested                                              |
-| [Transfer Complete Event](bxml/callBacks/transfer.md)  | Bandwidth API sends this event to the application when the `<Transfer>`is complete.                                              |
+BXML events are HTTP messages that are sent to your application server to notify you of activity related to your Bandwidth resources during a BXML usage.
+
+| Event                                             | Description                                                                                                                     |
+|:--------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| [Answer Event](callBacks/answer.md)               | Bandwidth API sends this message to the application when the call is answered.                                                  |
+| [Gather event](callBacks/gather.md)               | Bandwidth API generates a gather event when the gather command completes in a call.                                             |
+| [Hangup Event](callBacks/hangup.md)               | Bandwidth API sends this message to the application when the call ends.                                                         |
+| [Recording event](callBacks/recording.md)         | Bandwidth API sends this event to the application when an the recording media file is saved or an error occurs while saving it. |
+| [Transcription event](callBacks/transcription.md) | Bandwidth API sends this event to the application when the recording media file is transcribed if requested.                    |
+| [Redirect event](callBacks/redirect.md)           | Bandwidth API sends this event to the application when a `<Redirect>` is requested                                              |
+| [Transfer Complete Event](callBacks/transfer.md)  | Bandwidth API sends this event to the application when the `<Transfer>`is complete                                              |
 
 ## Error Codes
 | Type                         | Description                                                                |

--- a/bxml/bxml.md
+++ b/bxml/bxml.md
@@ -18,7 +18,7 @@ The events sent are the events from Bandwidth Application Platform, with only tw
 
 BXML callbacks perform HTTP GET requests to the **requestUrl** when the notification intends to retrieve a new BXML document.
 
-### Verbs
+### BXML Verbs
 
 | Verb                                        | Description                                                                                                                                                                         |
 |:--------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/methods/phoneNumbers/postImportPhoneNumber.md
+++ b/methods/phoneNumbers/postImportPhoneNumber.md
@@ -1,7 +1,7 @@
 {% method %}
 
 ## Import Phone Number
-Imoprt a previously orderd phone number from the Bandwidth Phone Number API so you can use it to make and receive calls and send and receive messages with the Voice And Messaing APIs. For more information about a new phone number, see the <a href="https://dev.bandwidth.com/faq/#Phone">FAQ</a>
+Import a previously orderd phone number from the Bandwidth Phone Number API so you can use it to make and receive calls and send and receive messages with the Voice And Messaing APIs. For more information about a new phone number, see the <a href="https://dev.bandwidth.com/faq/#Phone">FAQ</a>
 
 
 ### Request URL
@@ -109,10 +109,10 @@ client.PhoneNumber.create(importNumberPayload)
 
 ```
 
-{% sample lang="ruby" %}
+{% sample lang="php" %}
 
-```ruby
-## coming soon
+```php
+
 ```
 
 {% common %}


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
