### PR TITLE
Renamed bxml pages to specify voice and reduce confusion

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -119,7 +119,7 @@
    * [Timeout Event](apiCallbacks/timeout.md)
    * [Transcription Event – BETA](apiCallbacks/transcription.md)
 
-## BXML
+## BXML for Voice
 * [BXML Overview](bxml/bxmlOverview.md)
 * [BXML Concepts and Vocabulary](bxml/bxmlConcepts.md)
 * [BXML Verbs](bxml/bxml.md)

--- a/bxml/bxml.md
+++ b/bxml/bxml.md
@@ -1,6 +1,6 @@
-# Bandwidth XML (BXML)
+# BXML Verbs
 
-Bandwidth XML allows you to create a voice application as easily as you create a Web application. Using Bandwidth XML (or BXML) your application handles incoming call events using standard action verbs that are described in XML.
+BXML allows you to create a voice application as easily as you create a Web application. Using BXML, your application handles incoming call events using standard action verbs that are described in BXML.
 
 Before we begin creating a new BXML application you’ll need two things initially setup:
 

--- a/bxml/bxmlCallbacks.md
+++ b/bxml/bxmlCallbacks.md
@@ -1,4 +1,4 @@
-## BXML Callbacks
+# BXML Callbacks
 
 ###  Understanding BXML Callback Events
 The events sent are the events from Bandwidth Application Platform, with only two exceptions:

--- a/bxml/bxmlOverview.md
+++ b/bxml/bxmlOverview.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-BXML is a much simpler way to interact with a call. Rather than working with callbacks, BXML handles the call state for you so all you have to implement is the order of events. BXML has many built in features and is perfect for quick development.
+Bandwidth XML (BXML) is a much simpler way to interact with a call. Rather than working with callbacks, BXML handles the call state for you so all you have to implement is the order of events. BXML has many built in features and is perfect for quick development.
 
 ## Assumptions
 


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
