### PR TITLE
Fixed transcriptions typos

### DIFF
--- a/methods/transcriptions/getTranscriptions.md
+++ b/methods/transcriptions/getTranscriptions.md
@@ -21,9 +21,9 @@ Read More about Transcriptions in the <a href="https://dev.bandwidth.com/faq/#me
 | state              | The state of the transcription, `transcribing` `completed` `error`                                                                                                                |
 | text               | The transcribed text.                                                                                                                                                             |
 | time               | The date/time the transcription resource was created (UTC).                                                                                                                       |
-| chargeableDuration | The seconds between activeTime and endTime for the recording; this is the time that is going to be used to charge the resource. Note: transcriptions is billed in 1 minute units. |
+| chargeableDuration | The seconds between activeTime and endTime for the recording; this is the time that is going to be used to charge the resource. Note: transcriptions are billed in 1 minute units. |
 | textSize           | The size of the transcribed text. If the text is longer than 1000 characters it will be cropped; the full text can be retrieved from the url available at textUrl property.       |
-| textUrl            | An url to the full text; this property is available regardless the textSize.                                                                                                      |
+| textUrl            | An url to the full text; this property is available regardless of the textSize.                                                                                                      |
 
 {% common %}
 

--- a/methods/transcriptions/getTranscriptionsTranscriptionId.md
+++ b/methods/transcriptions/getTranscriptionsTranscriptionId.md
@@ -16,9 +16,9 @@ Get information about the transcription, regardless its state.
 | state              | The state of the transcription, `transcribing` `completed` `error`                                                                                                                |
 | text               | The transcribed text.                                                                                                                                                             |
 | time               | The date/time the transcription resource was created (UTC).                                                                                                                       |
-| chargeableDuration | The seconds between activeTime and endTime for the recording; this is the time that is going to be used to charge the resource. Note: transcriptions is billed in 1 minute units. |
+| chargeableDuration | The seconds between activeTime and endTime for the recording; this is the time that is going to be used to charge the resource. Note: transcriptions are billed in 1 minute units. |
 | textSize           | The size of the transcribed text. If the text is longer than 1000 characters it will be cropped; the full text can be retrieved from the url available at textUrl property.       |
-| textUrl            | An url to the full text; this property is available regardless the textSize.                                                                                                      |
+| textUrl            | An url to the full text; this property is available regardless of the textSize.                                                                                                      |
 
 {% common %}
 


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
