### PR TITLE
Added missing verbs to bxmlOverview

### DIFF
--- a/bxml/bxmlOverview.md
+++ b/bxml/bxmlOverview.md
@@ -56,7 +56,9 @@ The call must be active in order to send BXML. BXML has the ability to do the fo
 * [Play Audio](verbs/playAudio.md): play a .mp3 or .wav audio file into a call
 * [Speak Sentence](verbs/speakSentence.md): Speak any sentence into the call
 * [Gather](verbs/gather.md):  Collects digits from the user. This would be used in a call tree (ex. Press 1 for more options press)
-* [Record](verbs/record.md): Record the user. This is often used for voicemail.
-* [Redirect](verbs/redirect.md): Directs the program from one block of code to another.
-* [Transfer](verbs/transfer.md): Transfer call from one number to another.
+* [Record](verbs/record.md): Record the user. This is often used for voicemail
+* [Redirect](verbs/redirect.md): Directs the program from one block of code to another
+* [Transfer](verbs/transfer.md): Transfer call from one number to another
 * [Hangup](verbs/hangup.md): Ends the call
+* [Pause](bxml/verbs/pause.md): Pauses the execution of the current BXML document
+* [SendDtmf](bxml/verbs/sendDtmf.md): Send DTMF digits to a call


### PR DESCRIPTION
## For the Committer

- [ ] I made sure that the site looks great and functions perfectly live
- [ ] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live
